### PR TITLE
Extension with optional arguments for tweets()

### DIFF
--- a/app/src/main/java/com/backstopmedia/kotlin/KotlinApplication.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/KotlinApplication.kt
@@ -43,7 +43,7 @@ class KotlinApplication : Application() {
     }
 }
 
-fun SearchService.tweets(s: String, geocode: Geocode? = null, s1: String? = null, s2: String? = null, s3: String? = null,
-                         integer: Int? = null, s4: String? = null, aLong: Long? = null, aLong1: Long? = null,
-                         aBoolean: Boolean? = null, callback: Callback<Search>) =
+fun SearchService.tweets(s: String? = null, geocode: Geocode? = null, s1: String? = null, s2: String? = null,
+                         s3: String? = null,integer: Int? = null, s4: String? = null, aLong: Long? = null,
+                         aLong1: Long? = null, aBoolean: Boolean? = null, callback: Callback<Search>) =
         tweets(s, geocode, s1, s2, s3, integer, s4, aLong, aLong1, aBoolean, callback)

--- a/app/src/main/java/com/backstopmedia/kotlin/KotlinApplication.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/KotlinApplication.kt
@@ -3,11 +3,10 @@ package com.backstopmedia.kotlin
 import android.app.Application
 import android.util.Log
 import com.backstopmedia.kotlin.twitter.MyTwitter
+import com.backstopmedia.kotlin.twitter.tweets
 import com.twitter.sdk.android.Twitter
 import com.twitter.sdk.android.core.*
 import com.twitter.sdk.android.core.models.Search
-import com.twitter.sdk.android.core.services.SearchService
-import com.twitter.sdk.android.core.services.params.Geocode
 import io.fabric.sdk.android.Fabric
 
 
@@ -42,8 +41,3 @@ class KotlinApplication : Application() {
         })
     }
 }
-
-fun SearchService.tweets(s: String? = null, geocode: Geocode? = null, s1: String? = null, s2: String? = null,
-                         s3: String? = null,integer: Int? = null, s4: String? = null, aLong: Long? = null,
-                         aLong1: Long? = null, aBoolean: Boolean? = null, callback: Callback<Search>) =
-        tweets(s, geocode, s1, s2, s3, integer, s4, aLong, aLong1, aBoolean, callback)

--- a/app/src/main/java/com/backstopmedia/kotlin/KotlinApplication.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/KotlinApplication.kt
@@ -6,6 +6,8 @@ import com.backstopmedia.kotlin.twitter.MyTwitter
 import com.twitter.sdk.android.Twitter
 import com.twitter.sdk.android.core.*
 import com.twitter.sdk.android.core.models.Search
+import com.twitter.sdk.android.core.services.SearchService
+import com.twitter.sdk.android.core.services.params.Geocode
 import io.fabric.sdk.android.Fabric
 
 
@@ -21,22 +23,27 @@ class KotlinApplication : Application() {
 
         // Test run (or twitter the hard way!)
         // We should be able to hack away a lot of this boilerplate.
-        Twitter.getInstance().core.logInGuest(object: Callback<AppSession>() {
+        Twitter.getInstance().core.logInGuest(object : Callback<AppSession>() {
             override fun failure(p0: TwitterException?) {
                 throw UnsupportedOperationException()
             }
 
             override fun success(p0: Result<AppSession>?) {
-                Twitter.getApiClient().searchService.tweets("Kotlin", null, null, null, null, null, null, null, null, null, object: Callback<Search>() {
+                Twitter.getApiClient().searchService.tweets("Kotlin", callback = object : Callback<Search>() {
                     override fun failure(p0: TwitterException?) {
                         throw UnsupportedOperationException()
                     }
 
                     override fun success(p0: Result<Search>?) {
-                        Log.d("Kotlin", "Found ${p0?.data?.tweets?.size()?:0} tweets")
+                        Log.d("Kotlin", "Found ${p0?.data?.tweets?.size() ?: 0} tweets")
                     }
                 })
             }
         })
     }
 }
+
+fun SearchService.tweets(s: String, geocode: Geocode? = null, s1: String? = null, s2: String? = null, s3: String? = null,
+                         integer: Int? = null, s4: String? = null, aLong: Long? = null, aLong1: Long? = null,
+                         aBoolean: Boolean? = null, callback: Callback<Search>) =
+        tweets(s, geocode, s1, s2, s3, integer, s4, aLong, aLong1, aBoolean, callback)

--- a/app/src/main/java/com/backstopmedia/kotlin/twitter/TwitterExtensions.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/twitter/TwitterExtensions.kt
@@ -1,0 +1,11 @@
+package com.backstopmedia.kotlin.twitter
+
+import com.twitter.sdk.android.core.Callback
+import com.twitter.sdk.android.core.models.Search
+import com.twitter.sdk.android.core.services.SearchService
+import com.twitter.sdk.android.core.services.params.Geocode
+
+fun SearchService.tweets(s: String? = null, geocode: Geocode? = null, s1: String? = null, s2: String? = null,
+                         s3: String? = null,integer: Int? = null, s4: String? = null, aLong: Long? = null,
+                         aLong1: Long? = null, aBoolean: Boolean? = null, callback: Callback<Search>) =
+        tweets(s, geocode, s1, s2, s3, integer, s4, aLong, aLong1, aBoolean, callback)

--- a/app/src/main/java/com/backstopmedia/kotlin/twitter/TwitterExtensions.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/twitter/TwitterExtensions.kt
@@ -5,7 +5,7 @@ import com.twitter.sdk.android.core.models.Search
 import com.twitter.sdk.android.core.services.SearchService
 import com.twitter.sdk.android.core.services.params.Geocode
 
-fun SearchService.tweets(s: String? = null, geocode: Geocode? = null, s1: String? = null, s2: String? = null,
-                         s3: String? = null,integer: Int? = null, s4: String? = null, aLong: Long? = null,
-                         aLong1: Long? = null, aBoolean: Boolean? = null, callback: Callback<Search>) =
-        tweets(s, geocode, s1, s2, s3, integer, s4, aLong, aLong1, aBoolean, callback)
+fun SearchService.tweets(query: String? = null, geocode: Geocode? = null, lang: String? = null, locale: String? = null,
+                         resultType: String? = null, count: Int? = null, until: String? = null, sinceId: Long? = null,
+                         maxId: Long? = null, includeEntities: Boolean? = null, callback: Callback<Search>) =
+        tweets(query, geocode, lang, locale, resultType, count, until, sinceId, maxId, includeEntities, callback)


### PR DESCRIPTION
I've created extension for `tweets()` method to make call to `SearchService` more readable:

```
fun SearchService.tweets(s: String, geocode: Geocode? = null, s1: String? = null, s2: String? = null, s3: String? = null,
                         integer: Int? = null, s4: String? = null, aLong: Long? = null, aLong1: Long? = null,
                         aBoolean: Boolean? = null, callback: Callback<Search>) =
        tweets(s, geocode, s1, s2, s3, integer, s4, aLong, aLong1, aBoolean, callback)
```
