### PR TITLE
Kallback, a much more friendly callback class

### DIFF
--- a/app/src/main/java/com/backstopmedia/kotlin/KotlinApplication.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/KotlinApplication.kt
@@ -2,17 +2,14 @@ package com.backstopmedia.kotlin
 
 import android.app.Application
 import android.util.Log
+import android.widget.Toast
 import com.backstopmedia.kotlin.twitter.MyTwitter
+import com.backstopmedia.kotlin.twitter.kallback
 import com.twitter.sdk.android.Twitter
 import com.twitter.sdk.android.core.*
 import com.twitter.sdk.android.core.models.Search
 import io.fabric.sdk.android.Fabric
 
-
-/**
- * Created by Aaron Sarazan on 10/10/15.
- * Copyright(c) 2015 Level, Inc.
- */
 class KotlinApplication : Application() {
 
     override fun onCreate() {
@@ -21,22 +18,14 @@ class KotlinApplication : Application() {
 
         // Test run (or twitter the hard way!)
         // We should be able to hack away a lot of this boilerplate.
-        Twitter.getInstance().core.logInGuest(object: Callback<AppSession>() {
-            override fun failure(p0: TwitterException?) {
-                throw UnsupportedOperationException()
-            }
-
-            override fun success(p0: Result<AppSession>?) {
-                Twitter.getApiClient().searchService.tweets("Kotlin", null, null, null, null, null, null, null, null, null, object: Callback<Search>() {
-                    override fun failure(p0: TwitterException?) {
-                        throw UnsupportedOperationException()
+        Twitter.getInstance().core.logInGuest(kallback {
+            Twitter.getApiClient().searchService.tweets("Kotlin", null, null, null, null, null, null, null, null, null,
+                    kallback {
+                        Toast.makeText(this,
+                                "Fetched ${it.data.tweets.size()} tweets", Toast.LENGTH_LONG)
+                                .show()
                     }
-
-                    override fun success(p0: Result<Search>?) {
-                        Log.d("Kotlin", "Found ${p0?.data?.tweets?.size()?:0} tweets")
-                    }
-                })
-            }
+            )
         })
     }
 }

--- a/app/src/main/java/com/backstopmedia/kotlin/twitter/Kallback.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/twitter/Kallback.kt
@@ -1,14 +1,18 @@
 package com.backstopmedia.kotlin.twitter
 
+import android.util.Log
+import android.widget.Toast
 import com.twitter.sdk.android.core.Callback
 import com.twitter.sdk.android.core.Result
 import com.twitter.sdk.android.core.TwitterException
 
 fun <T: Any> kallback(onSuccess: (Result<T>) -> Unit = {}): Kallback<T> {
-    return Kallback(onSuccess)
+    return Kallback(onSuccess).onFail {
+        Log.e("kallback", "Something went wrong: $it")
+    }
 }
 
-class Kallback<T: Any>(success: (Result<T>) -> Unit) : Callback<T>() {
+open class Kallback<T: Any>(success: (Result<T>) -> Unit) : Callback<T>() {
 
     private val onSuccess: (Result<T>) -> Unit = success
     private var onFail: (TwitterException) -> Unit = {}

--- a/app/src/main/java/com/backstopmedia/kotlin/twitter/Kallback.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/twitter/Kallback.kt
@@ -1,0 +1,28 @@
+package com.backstopmedia.kotlin.twitter
+
+import com.twitter.sdk.android.core.Callback
+import com.twitter.sdk.android.core.Result
+import com.twitter.sdk.android.core.TwitterException
+
+fun <T: Any> kallback(onSuccess: (Result<T>) -> Unit = {}): Kallback<T> {
+    return Kallback(onSuccess)
+}
+
+class Kallback<T: Any>(success: (Result<T>) -> Unit) : Callback<T>() {
+
+    private val onSuccess: (Result<T>) -> Unit = success
+    private var onFail: (TwitterException) -> Unit = {}
+
+    fun onFail(fn: (TwitterException) -> Unit): Kallback<T> {
+        onFail = fn
+        return this
+    }
+
+    override fun success(result: Result<T>) {
+        onSuccess.invoke(result)
+    }
+
+    override fun failure(exception: TwitterException) {
+        onFail.invoke(exception)
+    }
+}

--- a/app/src/main/java/com/backstopmedia/kotlin/twitter/MyTwitter.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/twitter/MyTwitter.kt
@@ -1,10 +1,5 @@
 package com.backstopmedia.kotlin.twitter
 
-
-/**
- * Created by Aaron Sarazan on 10/10/15.
- * Copyright(c) 2015 Level, Inc.
- */
 object MyTwitter {
     // Note: Your consumer key and secret should be obfuscated in your source code before shipping.
     const val KEY = "9zKVaamMBSsSkihrQeRLYS8us"


### PR DESCRIPTION
This creates a specialty subclass of retrofit.Callback<T> which can be called thusly:

``` kotlin
Twitter.getApiClient().searchService.tweets("Kotlin", callback = kallback { /*YAY SUCCESS*/ })
```

Providing a failure state is a little more difficult as the chaining seems to confuse type inference.
