### PR TITLE
nullable onFail property

### DIFF
--- a/app/src/main/java/com/backstopmedia/kotlin/twitter/Kallback.kt
+++ b/app/src/main/java/com/backstopmedia/kotlin/twitter/Kallback.kt
@@ -15,7 +15,7 @@ fun <T: Any> kallback(onSuccess: (Result<T>) -> Unit = {}): Kallback<T> {
 open class Kallback<T: Any>(success: (Result<T>) -> Unit) : Callback<T>() {
 
     private val onSuccess: (Result<T>) -> Unit = success
-    private var onFail: (TwitterException) -> Unit = {}
+    private var onFail: ((TwitterException) -> Unit)? = null
 
     fun onFail(fn: (TwitterException) -> Unit): Kallback<T> {
         onFail = fn
@@ -27,6 +27,6 @@ open class Kallback<T: Any>(success: (Result<T>) -> Unit) : Callback<T>() {
     }
 
     override fun failure(exception: TwitterException) {
-        onFail.invoke(exception)
+        onFail?.invoke(exception)
     }
 }


### PR DESCRIPTION
I think that it might be better to define `onFail` property in `Kallback` as nullable instead of empty function by default, like this:
`private var onFail: ((TwitterException) -> Unit)? = null`
and then invoke it using safe call:
`onFail?.invoke(exception)`

What do you think?
